### PR TITLE
[#145603685] Don't clear the page logs onNavigationRequested.

### DIFF
--- a/src/session.js
+++ b/src/session.js
@@ -607,12 +607,6 @@ ghostdriver.Session = function(desiredCapabilities) {
                 error: req
             });
         };
-        page.onNavigationRequested = function(url, type, willNavigate, main) {
-            // Clear page log before page loading
-            if (main && willNavigate) {
-                _clearPageLog(page);
-            }
-        };
 
         _decoratePromptBehavior(page);
 


### PR DESCRIPTION
AJAX calls during a perform could result in new page loads, which would
trigger page.onNavigationRequested and thus clear the HAR contents so
far. So keep the logs regardless and trust the engine to clear them at
the start of every perform (when it builds a new HAR).