### PR TITLE
[#151246782] Further fix to delivery times when exchange timings are …

### DIFF
--- a/src/third_party/har.js
+++ b/src/third_party/har.js
@@ -105,11 +105,13 @@ exports.createHar = function (page, resources) {
             entry.time = endReply.time - request.time;
 
             if (entry.time > 3600000) {
-                // Found wierd bug (#150127455)
+                // Found weird bug (#150127455)
                 entry.debug = {};
                 entry.debug.endReplyTime = endReply.time.valueOf();
                 entry.debug.requestTime = request.time.valueOf();
-                entry.time -= 3600000;
+
+                request.time = new Date(request.time.getTime() + 3600000);
+                entry.time = endReply.time - request.time;
             }
 
             if (startReply) {
@@ -118,7 +120,7 @@ exports.createHar = function (page, resources) {
                 entry.timings.receive = endReply.time - startReply.time;
 
                 if (entry.timings.receive < 0) {
-                    // Found wierd bug (#150127455)
+                    // Found weird bug (#150127455)
                     entry.debug = {};
                     entry.debug.startReplyTime = startReply.time.valueOf();
                     entry.debug.endReplyTime = endReply.time.valueOf();

--- a/src/third_party/har.js
+++ b/src/third_party/har.js
@@ -32,6 +32,15 @@ exports.createHar = function (page, resources) {
             endReply = resource.endReply,
             error = resource.error;
 
+        function setTimeFromTimestamp(event) {
+            if (event) {
+                event.time = new Date(event.timestamp);
+            }
+        }
+        setTimeFromTimestamp(request);
+        setTimeFromTimestamp(startReply);
+        setTimeFromTimestamp(endReply);
+
         if (!request) {
             return;
         }
@@ -104,29 +113,10 @@ exports.createHar = function (page, resources) {
         if (endReply) {
             entry.time = endReply.time - request.time;
 
-            if (entry.time > 3600000) {
-                // Found weird bug (#150127455)
-                entry.debug = {};
-                entry.debug.endReplyTime = endReply.time.valueOf();
-                entry.debug.requestTime = request.time.valueOf();
-
-                request.time = new Date(request.time.getTime() + 3600000);
-                entry.time = endReply.time - request.time;
-            }
-
             if (startReply) {
                 // Certain requests (redirects, synchronous AJAX requests) will not receive
                 // onResourceReceived with stage "start".
                 entry.timings.receive = endReply.time - startReply.time;
-
-                if (entry.timings.receive < 0) {
-                    // Found weird bug (#150127455)
-                    entry.debug = {};
-                    entry.debug.startReplyTime = startReply.time.valueOf();
-                    entry.debug.endReplyTime = endReply.time.valueOf();
-                    entry.debug.requestTime = request.time.valueOf();
-                    delete entry.timings.receive;
-                }
             } else {
                 fillInHeaders(endReply);
             }


### PR DESCRIPTION
…mysteriously an hour out.

Adjust `request.time` directly, not just `entry.time`, because `request.time` is used to compute step delivery times.